### PR TITLE
Introduced all supported compression formats to C api.

### DIFF
--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -190,7 +190,13 @@ LEVELDB_EXPORT void leveldb_options_set_block_restart_interval(
 LEVELDB_EXPORT void leveldb_options_set_max_file_size(leveldb_options_t*,
                                                       size_t);
 
-enum { leveldb_no_compression = 0, leveldb_snappy_compression = 1 };
+enum {
+	leveldb_no_compression = 0,
+	leveldb_snappy_compression = 1,
+	leveldb_zstd_compression = 2,
+	leveldb_zlib_raw_compression = 4
+};
+
 LEVELDB_EXPORT void leveldb_options_set_compression(leveldb_options_t*, int);
 
 /* Comparator */


### PR DESCRIPTION
This newer fork of leveldb does not contain the definitions for the supported compression formats in its C api. These definitions were previously found in the original [leveldb-mcpe fork](https://github.com/vhebert-gh/levedb-mcpe-legacy/blob/master/include/leveldb/c.h#L203-L210). These definitions are not required from a calling convention perspective, but they do better express intent to users who might want to use this fork in the development of third party tools.