### PR TITLE
Task AB#1310797: [LevelDB] Allow passing in nullptr to get() to save a bit of performance on pure lookups

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -122,8 +122,10 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s) {
       const uint64_t tag = DecodeFixed64(key_ptr + key_length - 8);
       switch (static_cast<ValueType>(tag & 0xff)) {
         case kTypeValue: {
-          Slice v = GetLengthPrefixedSlice(key_ptr + key_length);
-          value->assign(v.data(), v.size());
+		  if (value) {
+			Slice v = GetLengthPrefixedSlice(key_ptr + key_length);
+			value->assign(v.data(), v.size());
+		  }
           return true;
         }
         case kTypeDeletion:

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -267,7 +267,7 @@ static void SaveValue(void* arg, const Slice& ikey, const Slice& v) {
   } else {
     if (s->ucmp->Compare(parsed_key.user_key, s->user_key) == 0) {
       s->state = (parsed_key.type == kTypeValue) ? kFound : kDeleted;
-      if (s->state == kFound) {
+      if (s->state == kFound && s->value) {
         s->value->assign(v.data(), v.size());
       }
     }


### PR DESCRIPTION
https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/1310797


Moving over the following commit: https://github.com/Mojang/leveldb-mcpe/commit/ad41261fc7d52bbad90a537388af468ab0e077fe

This is a feature we use.