### PR TITLE
Task AB# 1310789: [LevelDB] Add mechanism to request suspension of background (BG Thread) tasks, to allow the db to go into a suspended state and fix deadlock caused by mechanism

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -51,9 +51,9 @@ class DBImpl : public DB {
   // Set the suspend flag, which tells the database not to schedule background
   // work until resume
   // Waits for any currently executing BG work to complete before returning
-  virtual void SuspendCompaction();
+  void SuspendCompaction() override;
   // Clears the suspend flag, so that the database can schedule background work
-  virtual void ResumeCompaction();
+  void ResumeCompaction() override;
 
   // Extra methods (for testing) that are not in the public DB interface
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -48,6 +48,12 @@ class DBImpl : public DB {
   bool GetProperty(const Slice& property, std::string* value) override;
   void GetApproximateSizes(const Range* range, int n, uint64_t* sizes) override;
   void CompactRange(const Slice* begin, const Slice* end) override;
+  // Set the suspend flag, which tells the database not to schedule background
+  // work until resume
+  // Waits for any currently executing BG work to complete before returning
+  virtual void SuspendCompaction();
+  // Clears the suspend flag, so that the database can schedule background work
+  virtual void ResumeCompaction();
 
   // Extra methods (for testing) that are not in the public DB interface
 
@@ -194,6 +200,9 @@ class DBImpl : public DB {
 
   // Has a background compaction been scheduled or is running?
   bool background_compaction_scheduled_ GUARDED_BY(mutex_);
+
+  // Has anyone issued a request to suspend background work?
+  std::atomic<bool> suspending_compaction_;
 
   ManualCompaction* manual_compaction_ GUARDED_BY(mutex_);
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -202,7 +202,7 @@ class DBImpl : public DB {
   bool background_compaction_scheduled_ GUARDED_BY(mutex_);
 
   // Has anyone issued a request to suspend background work?
-  std::atomic<bool> suspending_compaction_;
+  std::atomic<bool> suspending_compaction_ GUARDED_BY(mutex_);
 
   ManualCompaction* manual_compaction_ GUARDED_BY(mutex_);
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2169,6 +2169,10 @@ class ModelDB : public DB {
   }
   void CompactRange(const Slice* start, const Slice* end) override {}
 
+  void SuspendCompaction() override {}
+
+  void ResumeCompaction() override {}
+
  private:
   class ModelIter : public Iterator {
    public:

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -145,6 +145,12 @@ class LEVELDB_EXPORT DB {
   // Therefore the following call will compact the entire database:
   //    db->CompactRange(nullptr, nullptr);
   virtual void CompactRange(const Slice* begin, const Slice* end) = 0;
+
+  // Allows the underlying storage to prepare for an application suspend event
+  virtual void SuspendCompaction() = 0;
+
+  // Allow the underlying storage to react to an application resume event
+  virtual void ResumeCompaction() = 0;
 };
 
 // Destroy the contents of the specified database.


### PR DESCRIPTION
https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/1310789

First commit moved over the mechanism to request suspension of background task from leveldb-mcpe https://github.com/Mojang/leveldb-mcpe/commit/7350473ed5410dec7da2e5e5ae46617f284767e9. Some adjustment were made to this cherry-picked commit because of changes made to the upstream:
* moved from custom `port::AtomicPointer` implementation to `std::atomic<bool>` for `suspending_compaction_` in db_impl.cc, looking for feedback on use of the correct memory order for the .load and .store functions in db_impl.cc
* variable name change from `bg_compaction_scheduled_` to `background_compaction_scheduled_` in db_impl.cc
* variable name change from `bg_cv` to `background_work_finished_signal_` in db_impl.cc
* added Resume and Suspend compaction functions to db_test.cc since `ModelDB` class inherits from `DB`

Second commit moved over fix for a deadlock scenerio this mechanism caused: https://github.com/Mojang/leveldb-mcpe/commit/ed63c8e4b2349e86b441cfc97bb2ba7d9b4f0ed8. Some adjustment were made to this cherry-picked commit because of changes made to the upstream:
* use of `NULL` changed to `nullptr` 
* added `GUARDED_BY(mutex_)` to `suspending_compaction_` in db_impl.h

Third commit fixed failing test by removing virtual keyword and adding override to ResumeCompaction and SuspendCompaction which now match format of other function in db_impl.h