### PR TITLE
Task AB#1310796: [LevelDB] Tweaks to level0 file limits

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -28,10 +28,10 @@ static const int kNumLevels = 7;
 static const int kL0_CompactionTrigger = 4;
 
 // Soft limit on number of level-0 files.  We slow down writes at this point.
-static const int kL0_SlowdownWritesTrigger = 8;
+static const int kL0_SlowdownWritesTrigger = 16;
 
 // Maximum number of level-0 files.  We stop writes at this point.
-static const int kL0_StopWritesTrigger = 12;
+static const int kL0_StopWritesTrigger = 64;
 
 // Maximum level to which a new compacted memtable is pushed if it
 // does not create overlap.  We try to push to level 2 to avoid the


### PR DESCRIPTION
https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/1310796

Moved over changes to soft limit and max number of level-0 file in accordance with https://github.com/Mojang/leveldb-mcpe/commit/fbeed5d06c7b4fdbd10cf11a3f2dc0ef52e804e0. Some adjustment were made to this cherry-picked commit because of changes made to the upstream:

* Didn't move over changes made to `winrt.cc` since this environment isn't getting moved over