### PR TITLE
Task AB#1355842: [LevelDB] - Add legacy Zlib compression support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ endif (WIN32)
 option(LEVELDB_BUILD_TESTS "Build LevelDB's unit tests" ON)
 option(LEVELDB_BUILD_BENCHMARKS "Build LevelDB's benchmarks" ON)
 option(LEVELDB_INSTALL "Install LevelDB's header and library" ON)
-
 option(LEVELDB_SUPPORT_LEGACY_ZLIB "Legacy Zlib Support" OFF)
 
 include(CheckIncludeFile)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ option(LEVELDB_BUILD_TESTS "Build LevelDB's unit tests" ON)
 option(LEVELDB_BUILD_BENCHMARKS "Build LevelDB's benchmarks" ON)
 option(LEVELDB_INSTALL "Install LevelDB's header and library" ON)
 
+option(LEVELDB_SUPPORT_LEGACY_ZLIB "Legacy Zlib Support" OFF)
+
 include(CheckIncludeFile)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,15 @@ target_compile_definitions(leveldb
     # Used by port/port.h.
     ${LEVELDB_PLATFORM_NAME}=1
 )
+
+if(LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM)
+  target_compile_definitions(leveldb
+  PRIVATE
+    # Used in format.cc
+    LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM
+  )
+endif(LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM)
+
 if (NOT HAVE_CXX17_HAS_INCLUDE)
   target_compile_definitions(leveldb
     PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(LEVELDB_BUILD_TESTS "Build LevelDB's unit tests" ON)
 option(LEVELDB_BUILD_BENCHMARKS "Build LevelDB's benchmarks" ON)
 option(LEVELDB_INSTALL "Install LevelDB's header and library" ON)
 option(LEVELDB_DISABLE_RTTI "Disable Rtti" ON)
-option(LEVELDB_SUPPORT_LEGACY_ZLIB "Legacy Zlib Support" OFF)
+option(LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM "Legacy Zlib Support" OFF)
 
 include(CheckIncludeFile)
 check_include_file("unistd.h" HAVE_UNISTD_H)

--- a/port/port_config.h.in
+++ b/port/port_config.h.in
@@ -35,4 +35,9 @@
 #cmakedefine01 HAVE_ZSTD
 #endif  // !defined(HAVE_ZSTD)
 
+// Define to 1 to enable Zlib legacy support.
+#if !defined(LEVELDB_SUPPORT_LEGACY_ZLIB)
+#cmakedefine01 LEVELDB_SUPPORT_LEGACY_ZLIB
+#endif  // !defined(LEVELDB_SUPPORT_LEGACY_ZLIB)
+
 #endif  // STORAGE_LEVELDB_PORT_PORT_CONFIG_H_

--- a/port/port_config.h.in
+++ b/port/port_config.h.in
@@ -40,9 +40,4 @@
 #cmakedefine01 HAVE_ZLIB
 #endif  // !defined(HAVE_ZLIB)
 
-// Define to 1 to enable Zlib legacy support.
-#if !defined(LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM)
-#cmakedefine01 LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM
-#endif  // !defined(LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM)
-
 #endif  // STORAGE_LEVELDB_PORT_PORT_CONFIG_H_

--- a/port/port_config.h.in
+++ b/port/port_config.h.in
@@ -41,8 +41,8 @@
 #endif  // !defined(HAVE_ZLIB)
 
 // Define to 1 to enable Zlib legacy support.
-#if !defined(LEVELDB_SUPPORT_LEGACY_ZLIB)
-#cmakedefine01 LEVELDB_SUPPORT_LEGACY_ZLIB
-#endif  // !defined(LEVELDB_SUPPORT_LEGACY_ZLIB)
+#if !defined(LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM)
+#cmakedefine01 LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM
+#endif  // !defined(LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM)
 
 #endif  // STORAGE_LEVELDB_PORT_PORT_CONFIG_H_

--- a/table/format.cc
+++ b/table/format.cc
@@ -138,7 +138,7 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
     case kZstdCompression: {
       size_t ulength = 0;
       if (!port::Zstd_GetUncompressedLength(data, n, &ulength)) {
-#if LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM
+#if defined(LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM)
         // Large leveldb consumer has an enum conflict between zstd and
         // non-raw zlib, this is here to remedy that
         std::string buffer;

--- a/table/format.cc
+++ b/table/format.cc
@@ -138,14 +138,8 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
     case kZstdCompression: {
       size_t ulength = 0;
       if (!port::Zstd_GetUncompressedLength(data, n, &ulength)) {
-		  // If compressed with zlib (not raw) the first byte will be 0x78
-		  // since we're using deflate and default LZ77 window size of 32K
-		  if (data[0] == 'x') {
-			  std::string buffer;
-			  if (!port::Zlib_Uncompress(data, n, &buffer)) {
-				delete[] buf;
-				return Status::Corruption("corrupted zstd or zlib compressed block");
-			  }
+          std::string buffer;
+		  if (port::Zlib_Uncompress(data, n, &buffer)) {
 			  auto ubuf = new char[buffer.size()];
 			  memcpy(ubuf, buffer.data(), buffer.size());
 			  delete[] buf;

--- a/table/format.cc
+++ b/table/format.cc
@@ -138,16 +138,16 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
     case kZstdCompression: {
       size_t ulength = 0;
       if (!port::Zstd_GetUncompressedLength(data, n, &ulength)) {
-          std::string buffer;
-		  if (port::Zlib_Uncompress(data, n, &buffer)) {
-			  auto ubuf = new char[buffer.size()];
-			  memcpy(ubuf, buffer.data(), buffer.size());
-			  delete[] buf;
-			  result->data = Slice(ubuf, buffer.size());
-			  result->heap_allocated = true;
-			  result->cachable = true;
-			  break;
-		} else {
+        std::string buffer;
+        if (port::Zlib_Uncompress(data, n, &buffer)) {
+          auto ubuf = new char[buffer.size()];
+          memcpy(ubuf, buffer.data(), buffer.size());
+          delete[] buf;
+          result->data = Slice(ubuf, buffer.size());
+          result->heap_allocated = true;
+          result->cachable = true;
+          break;
+        } else {
           delete[] buf;
           return Status::Corruption("corrupted zstd compressed block length");
         }

--- a/table/format.cc
+++ b/table/format.cc
@@ -138,8 +138,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
     case kZstdCompression: {
       size_t ulength = 0;
       if (!port::Zstd_GetUncompressedLength(data, n, &ulength)) {
-#if LEVELDB_SUPPORT_LEGACY_ZLIB
-        //Compression type 2 could indicate an old block compressed with non-raw zlib
+#if LEVELDB_SUPPORT_LEGACY_ZLIB_ENUM
+        // Large leveldb consumer has an enum conflict between zstd and
+        // non-raw zlib, this is here to remedy that
         std::string buffer;
         if (port::Zlib_Uncompress(data, n, &buffer)) {
           auto ubuf = new char[buffer.size()];

--- a/table/format.cc
+++ b/table/format.cc
@@ -139,13 +139,12 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
       size_t ulength = 0;
       if (!port::Zstd_GetUncompressedLength(data, n, &ulength)) {
 		  // If compressed with zlib (not raw) the first byte will be 0x78
-		  // Since we're using deflate and default LZ77 window size of 32K
+		  // since we're using deflate and default LZ77 window size of 32K
 		  if (data[0] == 'x') {
 			  std::string buffer;
 			  if (!port::Zlib_Uncompress(data, n, &buffer)) {
 				delete[] buf;
-				return Status::Corruption(
-					"corrupted zlib compressed block contents");
+				return Status::Corruption("corrupted zstd or zlib compressed block");
 			  }
 			  auto ubuf = new char[buffer.size()];
 			  memcpy(ubuf, buffer.data(), buffer.size());


### PR DESCRIPTION
https://dev.azure.com/dev-mc/Minecraft/_workitems/edit/1355842

* Follow-up pr to https://github.com/Mojang/leveldb/pull/12
* Adding ability to read block with compression id of 2 which signify an older bedrock world compressed using zlib with a header and trailer(non-raw)
* Zlib checks the check value in the header, so extra validation isn't done in `format.cc` to determine if `input` is a zlib frame before attempting a decompress