### PR TITLE
Task AB#1310798: [LevelDB] Add DecompressAllocator class that allows the host app to handle some reusable buffers for decompression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ target_sources(leveldb
     "${LEVELDB_PUBLIC_INCLUDE_DIR}/cache.h"
     "${LEVELDB_PUBLIC_INCLUDE_DIR}/comparator.h"
     "${LEVELDB_PUBLIC_INCLUDE_DIR}/db.h"
+    "${LEVELDB_PUBLIC_INCLUDE_DIR}/decompress_allocator.h"
     "${LEVELDB_PUBLIC_INCLUDE_DIR}/dumpfile.h"
     "${LEVELDB_PUBLIC_INCLUDE_DIR}/env.h"
     "${LEVELDB_PUBLIC_INCLUDE_DIR}/export.h"

--- a/include/leveldb/decompress_allocator.h
+++ b/include/leveldb/decompress_allocator.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#ifndef LEVELDB_DECOMPRESS_ALLOCATOR_H_
+#define LEVELDB_DECOMPRESS_ALLOCATOR_H_
+
+#include <mutex>
+#include <vector>
+#include <string>
+
+namespace leveldb {
+	class DLLX DecompressAllocator {
+	public:
+		virtual ~DecompressAllocator();
+
+		virtual std::string get();
+		virtual void release(std::string&& string);
+
+		virtual void prune();
+
+	protected:
+		std::mutex mutex;
+		std::vector<std::string> stack;
+	};
+}
+
+#endif

--- a/include/leveldb/decompress_allocator.h
+++ b/include/leveldb/decompress_allocator.h
@@ -8,19 +8,17 @@
 #include <string>
 
 namespace leveldb {
-	class DLLX DecompressAllocator {
-	public:
-		virtual ~DecompressAllocator();
+class DLLX DecompressAllocator {
+ public:
+  virtual ~DecompressAllocator();
+  virtual std::string get();
+  virtual void release(std::string&& string);
+  virtual void prune();
 
-		virtual std::string get();
-		virtual void release(std::string&& string);
-
-		virtual void prune();
-
-	protected:
-		std::mutex mutex;
-		std::vector<std::string> stack;
-	};
+ protected:
+  std::mutex mutex;
+  std::vector<std::string> stack;
+};
 }
 
 #endif

--- a/include/leveldb/decompress_allocator.h
+++ b/include/leveldb/decompress_allocator.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #ifndef LEVELDB_DECOMPRESS_ALLOCATOR_H_
 #define LEVELDB_DECOMPRESS_ALLOCATOR_H_
 
@@ -8,17 +6,25 @@
 #include <string>
 
 namespace leveldb {
+
 class LEVELDB_EXPORT DecompressAllocator {
  public:
+  DecompressAllocator() = default;
+
   virtual ~DecompressAllocator();
+
   virtual std::string get();
+
   virtual void release(std::string&& string);
+
   virtual void prune();
 
  protected:
   std::mutex mutex;
+
   std::vector<std::string> stack;
 };
-}
 
-#endif
+}  // namespace leveldb
+
+#endif  // LEVELDB_DECOMPRESS_ALLOCATOR_H_

--- a/include/leveldb/decompress_allocator.h
+++ b/include/leveldb/decompress_allocator.h
@@ -8,7 +8,7 @@
 #include <string>
 
 namespace leveldb {
-class DLLX DecompressAllocator {
+class LEVELDB_EXPORT DecompressAllocator {
  public:
   virtual ~DecompressAllocator();
   virtual std::string get();

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -18,6 +18,7 @@ class FilterPolicy;
 class Logger;
 class Snapshot;
 class DecompressAllocator;
+
 // DB contents are stored in a set of blocks, each of which holds a
 // sequence of key,value pairs.  Each block may be compressed before
 // being stored in a file.  The following enum describes which

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -176,7 +176,7 @@ struct LEVELDB_EXPORT ReadOptions {
   
   // Allocator to grab the (possibly tens of mb big) blocks of memory 
   // where to decompress
-  DecompressAllocator* decompress_allocator;
+  DecompressAllocator* decompress_allocator = nullptr;
 };
 
 // Options that control write operations

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -176,7 +176,7 @@ struct LEVELDB_EXPORT ReadOptions {
   
   // Allocator to grab the (possibly tens of mb big) blocks of memory 
   // where to decompress
-  DecompressAllocator* decompressAllocator = nullptr;
+  DecompressAllocator* decompress_allocator;
 };
 
 // Options that control write operations

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -17,8 +17,7 @@ class Env;
 class FilterPolicy;
 class Logger;
 class Snapshot;
-
-// DB contents are stored in a set of blocks, each of which holds a
+class DecompressAllocator;
 // sequence of key,value pairs.  Each block may be compressed before
 // being stored in a file.  The following enum describes which
 // compression method (if any) is used to compress a block.
@@ -173,6 +172,10 @@ struct LEVELDB_EXPORT ReadOptions {
   // not have been released).  If "snapshot" is null, use an implicit
   // snapshot of the state at the beginning of this read operation.
   const Snapshot* snapshot = nullptr;
+  
+  // Allocator to grab the (possibly tens of mb big) blocks of memory 
+  // where to decompress
+  DecompressAllocator* decompressAllocator = nullptr;
 };
 
 // Options that control write operations

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -18,6 +18,7 @@ class FilterPolicy;
 class Logger;
 class Snapshot;
 class DecompressAllocator;
+// DB contents are stored in a set of blocks, each of which holds a
 // sequence of key,value pairs.  Each block may be compressed before
 // being stored in a file.  The following enum describes which
 // compression method (if any) is used to compress a block.

--- a/table/format.cc
+++ b/table/format.cc
@@ -166,9 +166,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
         // Large leveldb consumer has an enum conflict between zstd and
         // non-raw zlib, this is here to remedy that
         std::string buffer;
-          if (options.decompressAllocator) {
-            buffer = options.decompressAllocator->get();
-          }
+        if (options.decompress_allocator) {
+          buffer = options.decompress_allocator->get();
+        }
         if (port::Zlib_Uncompress(data, n, &buffer)) {
           auto ubuf = new char[buffer.size()];
           memcpy(ubuf, buffer.data(), buffer.size());
@@ -176,9 +176,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
           result->data = Slice(ubuf, buffer.size());
           result->heap_allocated = true;
           result->cachable = true;
-            if (options.decompressAllocator) {
-              options.decompressAllocator->release(std::move(buffer));
-            }
+          if (options.decompress_allocator) {
+            options.decompress_allocator->release(std::move(buffer));
+          }
           break;
         }
 #endif
@@ -199,8 +199,8 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
     }
     case kZlibRawCompression: {
       std::string buffer;
-      if (options.decompressAllocator) {
-        buffer = options.decompressAllocator->get();
+      if (options.decompress_allocator) {
+        buffer = options.decompress_allocator->get();
       }
       if (!port::Zlib_Uncompress(data, n, &buffer, true)) {
         delete[] buf;
@@ -212,8 +212,8 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
       result->data = Slice(ubuf,buffer.size());
       result->heap_allocated = true;
       result->cachable = true;
-      if (options.decompressAllocator) {
-	    options.decompressAllocator->release(std::move(buffer));
+      if (options.decompress_allocator) {
+	    options.decompress_allocator->release(std::move(buffer));
       }
       break;
     }

--- a/table/format.cc
+++ b/table/format.cc
@@ -14,7 +14,7 @@
 
 namespace leveldb {
 
-DecompressAllocator::~DecompressAllocator() {}
+DecompressAllocator::~DecompressAllocator() = default;
 
 std::string DecompressAllocator::get() {
   std::string buffer;

--- a/table/format.cc
+++ b/table/format.cc
@@ -213,7 +213,7 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
       result->heap_allocated = true;
       result->cachable = true;
       if (options.decompress_allocator) {
-	    options.decompress_allocator->release(std::move(buffer));
+        options.decompress_allocator->release(std::move(buffer));
       }
       break;
     }

--- a/table/format.cc
+++ b/table/format.cc
@@ -10,8 +10,32 @@
 #include "table/block.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
+#include "leveldb/decompress_allocator.h"
 
 namespace leveldb {
+
+DecompressAllocator::~DecompressAllocator() {}
+
+std::string DecompressAllocator::get() {
+  std::string buffer;
+  std::lock_guard<std::mutex> lock(mutex);
+  if (!stack.empty()) {
+    buffer = std::move(stack.back());
+    buffer.clear();
+    stack.pop_back();
+  }
+  return buffer;
+}
+
+void DecompressAllocator::release(std::string&& string) {
+  std::lock_guard<std::mutex> lock(mutex);
+  stack.push_back(std::move(string));
+}
+
+void DecompressAllocator::prune() {
+  std::lock_guard<std::mutex> lock(mutex);
+  stack.clear();
+}
 
 void BlockHandle::EncodeTo(std::string* dst) const {
   // Sanity check that all fields have been set
@@ -142,6 +166,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
         // Large leveldb consumer has an enum conflict between zstd and
         // non-raw zlib, this is here to remedy that
         std::string buffer;
+          if (options.decompressAllocator) {
+            buffer = options.decompressAllocator->get();
+          }
         if (port::Zlib_Uncompress(data, n, &buffer)) {
           auto ubuf = new char[buffer.size()];
           memcpy(ubuf, buffer.data(), buffer.size());
@@ -149,6 +176,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
           result->data = Slice(ubuf, buffer.size());
           result->heap_allocated = true;
           result->cachable = true;
+              if (options.decompressAllocator) {
+	            options.decompressAllocator->release(std::move(buffer));
+              }
           break;
         }
 #endif
@@ -169,6 +199,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
     }
     case kZlibRawCompression: {
       std::string buffer;
+      if (options.decompressAllocator) {
+        buffer = options.decompressAllocator->get();
+      }
       if (!port::Zlib_Uncompress(data, n, &buffer, true)) {
         delete[] buf;
         return Status::Corruption("corrupted zlib compressed block contents");
@@ -179,6 +212,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
       result->data = Slice(ubuf,buffer.size());
       result->heap_allocated = true;
       result->cachable = true;
+      if (options.decompressAllocator) {
+	    options.decompressAllocator->release(std::move(buffer));
+      }
       break;
     }
     default:
@@ -188,6 +224,5 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
 
   return Status::OK();
 }
-
 
 }  // namespace leveldb

--- a/table/format.cc
+++ b/table/format.cc
@@ -176,9 +176,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
           result->data = Slice(ubuf, buffer.size());
           result->heap_allocated = true;
           result->cachable = true;
-              if (options.decompressAllocator) {
-	            options.decompressAllocator->release(std::move(buffer));
-              }
+            if (options.decompressAllocator) {
+              options.decompressAllocator->release(std::move(buffer));
+            }
           break;
         }
 #endif
@@ -224,5 +224,6 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
 
   return Status::OK();
 }
+
 
 }  // namespace leveldb


### PR DESCRIPTION
Moving over `DecompressAllocator` from leveldb-mcpe:
* https://github.com/Mojang/leveldb-mcpe/commit/02ae5f63b1248e94c3c896ea8a862fd7f3c4b6a5
* https://github.com/Mojang/leveldb-mcpe/commit/030fbfea7a2a4c9878321102805db9245c346e62

Some minor changes made:
* The `DLLX` in `DecompressAllocator` class declaration was changed to `LEVELDB_EXPORT`
* `decompress_allocator` in options.h is set to `nullptr` instead of `NULL`
* White space added/removed to match standard used in other leveldb files